### PR TITLE
Added support for HC-06 firmware version 3.0-20170609

### DIFF
--- a/CurrentRanger_R1.ino
+++ b/CurrentRanger_R1.ino
@@ -198,7 +198,24 @@ void setup() {
       break;
     }
   }
-  SerialUSB.print(BT_found?"OK!":"no response.");
+
+  SerialUSB.print(BT_found?"OK!":"No response. Checking for version 3.0.\r\n");
+
+  if (!BT_found)
+  {
+    Serial.print("\r\n"); //assuming HC-06 version 3.0 that requires line ending
+    uint32_t timer=millis();
+    while(millis()-timer<50) //about 50ms to respond
+    {
+      if (Serial.available()==4 && Serial.read()=='O' && Serial.read()=='K' && Serial.read()=='\r' && Serial.read() == '\n')
+      {
+        BT_found=true;
+        break;
+      }
+    }
+  
+    SerialUSB.print(BT_found?"OK!":"No response.");
+  }
 
   //rangeMA(); //done in bootloader
   WDTset();


### PR DESCRIPTION
- New HC-06 firmware version 3.0-20170609 requires a line feed (CR/LF) included in AT commands. It also sends the line feed after each response. This version fixes the BlueTooth module recognition with the new HC-06 firmware version.