### PR TITLE
range up to mA to prevent brown outs

### DIFF
--- a/CurrentRanger_R1.ino
+++ b/CurrentRanger_R1.ino
@@ -283,8 +283,7 @@ void loop()
     }
     else if (readDiff >= RANGE_SWITCH_THRESHOLD_HIGH)
     {
-      if      (RANGE_NA) { rangeUA(); rangeSwitched=true; rangeBeep(SWITCHDELAY_UP); }
-      else if (RANGE_UA) { rangeMA(); rangeSwitched=true; rangeBeep(SWITCHDELAY_UP); }
+      rangeMA(); rangeSwitched=true; rangeBeep(SWITCHDELAY_UP);
     }
     if (rangeSwitched) {
       rangeSwitched=false;


### PR DESCRIPTION
Hi Felix, last one for the day, I promise...

For your consideration: I have a device, such that when under test, it will not function when waking from its OFF state if the CurrentRanger is in the nA scale.  The initial ON state consumes several hundred milliamps.

When trying to turn on my device, I can see the CurrentRanger switch into uA scale briefly, but back down to nA, and my device remains off.

This small patch will immediately switch to the mA scale if the code finds an overflow in the ADC.  This will let my device function when under test with auto ranging enabled.