### PR TITLE
Calibrate offset key change use & vs /

### DIFF
--- a/CurrentRanger_R3.ino
+++ b/CurrentRanger_R3.ino
@@ -331,7 +331,7 @@ void loop() {
         Serial.print("new offsetCorrectionValue = ");
         Serial.println(offsetCorrectionValue);
         break;
-      case '/':
+      case '&':
         eeprom_ADCoffset.write(--offsetCorrectionValue);
         analogReadCorrection(offsetCorrectionValue,gainCorrectionValue);
         Serial.print("new offsetCorrectionValue = ");
@@ -457,6 +457,8 @@ void loop() {
 
         break;
       case '?':
+      //print the menu on / or ?
+      case '/':
         printSerialMenu();
         break;
       default: break;
@@ -891,7 +893,7 @@ void printSerialMenu() {
   Serial.println("+ = Calibrate GAIN value (+1)");
   Serial.println("- = Calibrate GAIN value (-1)");
   Serial.println("* = Calibrate OFFSET value (+1)");
-  Serial.println("/ = Calibrate OFFSET value (-1)");
+  Serial.println("& = Calibrate OFFSET value (-1)");
   Serial.println("1 = range to MilliAmps (MA)");
   Serial.println("2 = range to MicroAmps (UA)");
   Serial.println("3 = range to NanoAmps (NA)");

--- a/CurrentRanger_R3.ino
+++ b/CurrentRanger_R3.ino
@@ -356,9 +356,6 @@ void loop() {
         USB_LOGGING_ENABLED =! USB_LOGGING_ENABLED;
         Serial.println(USB_LOGGING_ENABLED ? "USB_LOGGING_ENABLED" : "USB_LOGGING_DISABLED");
         break;
-      case 'U': //print the USB logging status
-        Serial.println(USB_LOGGING_ENABLED ? "USB_LOGGING_ENABLED" : "USB_LOGGING_DISABLED");
-        break;
       case 't': //toggle touchpad serial output debug info
         TOUCH_DEBUG_ENABLED =! TOUCH_DEBUG_ENABLED;
         Serial.println(TOUCH_DEBUG_ENABLED ? "TOUCH_DEBUG_ENABLED" : "TOUCH_DEBUG_DISABLED");
@@ -889,7 +886,6 @@ void printSerialMenu() {
   Serial.println("s = cycle ADC sampling speeds (0=average,faster,slower)");
   Serial.println("t = toggle touchpad serial output debug info");
   Serial.println("u = toggle USB/serial logging");
-  Serial.println("U = show USB/serial logging state");
   Serial.println("< = Calibrate LDO value (-1mV)");
   Serial.println("> = Calibrate LDO value (+1mV)");
   Serial.println("+ = Calibrate GAIN value (+1)");

--- a/CurrentRanger_R3.ino
+++ b/CurrentRanger_R3.ino
@@ -356,6 +356,9 @@ void loop() {
         USB_LOGGING_ENABLED =! USB_LOGGING_ENABLED;
         Serial.println(USB_LOGGING_ENABLED ? "USB_LOGGING_ENABLED" : "USB_LOGGING_DISABLED");
         break;
+      case 'U': //print the USB logging status
+        Serial.println(USB_LOGGING_ENABLED ? "USB_LOGGING_ENABLED" : "USB_LOGGING_DISABLED");
+        break;
       case 't': //toggle touchpad serial output debug info
         TOUCH_DEBUG_ENABLED =! TOUCH_DEBUG_ENABLED;
         Serial.println(TOUCH_DEBUG_ENABLED ? "TOUCH_DEBUG_ENABLED" : "TOUCH_DEBUG_DISABLED");
@@ -886,6 +889,7 @@ void printSerialMenu() {
   Serial.println("s = cycle ADC sampling speeds (0=average,faster,slower)");
   Serial.println("t = toggle touchpad serial output debug info");
   Serial.println("u = toggle USB/serial logging");
+  Serial.println("U = show USB/serial logging state");
   Serial.println("< = Calibrate LDO value (-1mV)");
   Serial.println("> = Calibrate LDO value (+1mV)");
   Serial.println("+ = Calibrate GAIN value (+1)");


### PR DESCRIPTION
On my keyboard ? and / are the same key. I changed the calibration offset value looking for the help. This change moves that function to the &. On my keyboard that is right next to *. Putting the keys for changing the calibration offset right next to each other.